### PR TITLE
Bugfix 04.06.18

### DIFF
--- a/src/DicSkill/MessageManager.java
+++ b/src/DicSkill/MessageManager.java
@@ -430,8 +430,8 @@ public class MessageManager {
 		
 		int shortenPosTo = ww.length(); // shortenPosTo equals the last pos of the ww
 		
-		// finds the position of the first " " starting from the end of the ww
-		while(!(ww.substring(shortenPosTo-1, shortenPosTo)).equals(new String(" ")) &&  shortenPosTo > 0) {
+		// finds the position of the first " " starting from the end/right of the ww
+		while( shortenPosTo > 0 && !(ww.substring(shortenPosTo-1, shortenPosTo).equals(new String(" ")) )) {
 			shortenPosTo--;
 		}
 		


### PR DESCRIPTION
function "shortenWishedWord" would throw an Index out of bound exception if the ww was null because of a mistake in line 434:
while( shortenPosTo > 0 && !(ww.substring(shortenPosTo-1, shortenPosTo).equals(new String(" ")) ))
The second part of the statement was written incorrectly, but was corrected in this version.