### PR TITLE
Update 28.06

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>DictionarySkill</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/src/DicSkill/Context.java
+++ b/src/DicSkill/Context.java
@@ -130,7 +130,7 @@ public class Context implements Serializable {
 	 * @param cat category the user wants to add
 	 */
 	private void addPrefCat(String cat) {
-		if(preferredCategory.contains(cat)) {
+		if(!preferredCategory.contains(cat)) {
 			preferredCategory.add(cat);
 			System.out.println(cat + " was added to your preferred categories.");
 		}

--- a/src/DicSkill/DatabaseCommunicator.java
+++ b/src/DicSkill/DatabaseCommunicator.java
@@ -92,7 +92,13 @@ public class DatabaseCommunicator {
 	private final Lucene lucene;
 	private String pos;                	// Rita specific: PartsOfSpeech. e.g.: noun, adjective, verb ...
 	private String[] leftoverResults;	// otherwise there will be no leftover result for spelling
-	private int MAX_RESULTS = 100; 		// need this, otherwise there will be no leftover results for scrabble functions (searches for specific amount of results directly)
+	
+	/*
+	 *  need MAX_RESULTS to improve performance for scrabble functions significantly. 
+	 *  Having no limit, will usually result in faster response, however there are 
+	 *  several seconds(!) waiting time upon the first request which would not meet the requirements.
+	 */
+	private int MAX_RESULTS = 100; 		
 
 	/** CONSTRUCTOR **/
 	public DatabaseCommunicator() {

--- a/src/DicSkill/Settings.java
+++ b/src/DicSkill/Settings.java
@@ -148,6 +148,7 @@ public class Settings implements Serializable
 		if(matcher.matches()) {
 			String number = matcher.group().replaceAll("\\D*",""); // gets number from msg
 			lastFailedNumberChange = Integer.parseInt(number); //remember number
+			newNOW = lastFailedNumberChange;
 			System.out.print("What function do you want to change the number of results for? You may choose: definitions, translations, synonyms, example, scrabble or all.");
 		}
 		// if number was not named, but function was
@@ -156,6 +157,7 @@ public class Settings implements Serializable
 		matcher = pattern.matcher(msg);
 		if(matcher.matches()) {
 			lastFailedFunctionChange = matcher.group(5); //remember function
+			foundFunction = lastFailedFunctionChange;
 			System.out.print("What number do you want to set it to?");
 		}
 		
@@ -181,7 +183,7 @@ public class Settings implements Serializable
 		
 		
 		if(newNOW==-1 && foundFunction==null) {
-			System.out.print("Sorry, you need to be more precise.");
+			System.out.print("Sorry, you need to be more precise. I need to know how many results you want to set for which function.");
 		}
 		
 	}

--- a/src/Tests/MainTest.java
+++ b/src/Tests/MainTest.java
@@ -1,5 +1,7 @@
 package Tests;
 
+import java.util.ArrayList;
+
 import org.junit.runner.*;
 import org.junit.runner.notification.Failure;
 
@@ -31,7 +33,8 @@ public class MainTest {
             System.out.println("    -> All queries take no longer than " +  PerformanceTest.MAX_TIME + " seconds");
         }
 
-        System.out.println("--- Finished testing Performance. Some queries take longer than " +  PerformanceTest.MAX_TIME + " seconds ---\n");
+        System.out.println("--- Finished testing Performance.");
+        //System.out.println("--- Finished testing Performance. Some queries take longer than " +  PerformanceTest.MAX_TIME + " seconds ---\n");
 
         return result;
     }
@@ -92,4 +95,6 @@ public class MainTest {
 
         return result;
     }
+
+   
 }

--- a/src/Tests/MessageManagerTest.java
+++ b/src/Tests/MessageManagerTest.java
@@ -110,12 +110,12 @@ public class MessageManagerTest {
         // Looking for context
         message = "provide me with more words";
         result = mm.decodeMsg(message, settings, databaseCom, context, state);
-        Assert.assertEquals("The translation of beautiful is wunderhÃ¼bsch." ,result);
+        Assert.assertEquals("The translation of beautiful is wunderhübsch." ,result);
 
         // Keep looking for context
         message = "provide me with even more words";
         result = mm.decodeMsg(message, settings, databaseCom, context, state);
-        Assert.assertEquals("The translation of beautiful is wunderschÃ¶n.", result);
+        Assert.assertEquals("The translation of beautiful is wunderschön.", result);
 
         // Evaluate if wished words was remembered
         message = "what are synonyms for it";
@@ -141,7 +141,7 @@ public class MessageManagerTest {
         result = mm.decodeMsg(message, settings, databaseCom, context, state);
         message = "what is the translation of great";
         result = mm.decodeMsg(message, settings, databaseCom, context, state);
-        Assert.assertEquals("The translations of great are groÃŸ, bedeutend, groÃŸartig, fabelhaft, fantastisch, phantastisch." ,result);
+        Assert.assertEquals("The translations of great are groß, bedeutend, großartig, fabelhaft, fantastisch, phantastisch." ,result);
 
         // Retverting changes for other tests
         message = "set the number of words for definitions to 1";
@@ -166,7 +166,7 @@ public class MessageManagerTest {
         // Long trail before
         message = "What is the translation of luck";
         result = mm.decodeMsg(message, settings, databaseCom, context, state);
-        Assert.assertEquals("The translation of luck is GlÃ¼ck." , result);
+        Assert.assertEquals("The translation of luck is Glück." , result);
 
         // Long trail after
         message = "translation of cool What the fuck jimmy put that down instantly or i will";

--- a/src/Tests/PerformanceTest.java
+++ b/src/Tests/PerformanceTest.java
@@ -2,9 +2,7 @@
  * 27.06.2018
  * NEW:
  * -    Performance test cases
- *
  * @author Walter
- *
  */
 
 package Tests;
@@ -24,7 +22,7 @@ import org.junit.Test;
  */
 public class PerformanceTest {
 
-    public static long MAX_TIME = 2;                // Maximum time for a query to be processed
+    public static double MAX_TIME = 1.0;                // Maximum time for a query to be processed
 
     private MessageManager mm;
     private State state;
@@ -56,14 +54,15 @@ public class PerformanceTest {
 
         String message = "What is the definition of luck";
 
-        long startTime = System.currentTimeMillis();
+        double startTime = System.currentTimeMillis();
 
         mm.decodeMsg(message, settings, databaseCom, context, state);
 
-        long endTime = System.currentTimeMillis();
-        long duration = (endTime - startTime) / 1000;      // Transform to seconds
+        double endTime = System.currentTimeMillis();
+        double duration = (endTime - startTime) / 1000;      // Convert from miliseconds to seconds
 
-        Assert.assertTrue(duration < MAX_TIME);
+        System.out.println("Definitions take "+duration+" seconds.");
+        Assert.assertTrue(duration <= MAX_TIME);
     }
 
     @Test
@@ -71,14 +70,15 @@ public class PerformanceTest {
 
         String message = "What is the translation of hardware";
 
-        long startTime = System.currentTimeMillis();
+        double startTime = System.currentTimeMillis();
 
         mm.decodeMsg(message, settings, databaseCom, context, state);
 
-        long endTime = System.currentTimeMillis();
-        long duration = (endTime - startTime) / 1000;      // Transform to seconds
+        double endTime = System.currentTimeMillis();
+        double duration = (endTime - startTime) / 1000;      // Convert from miliseconds to seconds
 
-        Assert.assertTrue(duration < MAX_TIME);
+        System.out.println("Translations take "+duration+" seconds.");
+        Assert.assertTrue(duration <= MAX_TIME);
     }
 
     @Test
@@ -86,14 +86,15 @@ public class PerformanceTest {
 
         String message = "please give me synonyms of true";
 
-        long startTime = System.currentTimeMillis();
+       	double startTime = System.currentTimeMillis();
 
         mm.decodeMsg(message, settings, databaseCom, context, state);
 
-        long endTime = System.currentTimeMillis();
-        long duration = (endTime - startTime) / 1000;      // Transform to seconds
+        double endTime = System.currentTimeMillis();
+        double duration = (endTime - startTime) / 1000;      // Convert from miliseconds to seconds
 
-        Assert.assertTrue(duration < MAX_TIME);
+        System.out.println("Synonyms take "+duration+" seconds.");
+        Assert.assertTrue(duration <= MAX_TIME);
     }
 
     @Test
@@ -101,14 +102,15 @@ public class PerformanceTest {
 
         String message = "examples of happy yes margaret, i will bring out the trash";
 
-        long startTime = System.currentTimeMillis();
+        double startTime = System.currentTimeMillis();
 
         mm.decodeMsg(message, settings, databaseCom, context, state);
 
-        long endTime = System.currentTimeMillis();
-        long duration = (endTime - startTime) / 1000;      // Transform to seconds
+        double endTime = System.currentTimeMillis();
+        double duration = (endTime - startTime) / 1000;      // Convert from miliseconds to seconds
 
-        Assert.assertTrue(duration < MAX_TIME);
+        System.out.println("Examples take "+duration+" seconds.");
+        Assert.assertTrue(duration <= MAX_TIME);
     }
 
     @Test
@@ -116,29 +118,31 @@ public class PerformanceTest {
 
         String message = "please spell bright";
 
-        long startTime = System.currentTimeMillis();
+        double startTime = System.currentTimeMillis();
 
         mm.decodeMsg(message, settings, databaseCom, context, state);
 
-        long endTime = System.currentTimeMillis();
-        long duration = (endTime - startTime) / 1000;      // Transform to seconds
+        double endTime = System.currentTimeMillis();
+        double duration = (endTime - startTime) / 1000;      // Convert from miliseconds to seconds
 
-        Assert.assertTrue(duration < MAX_TIME);
+        System.out.println("Spellings take "+duration+" seconds.");
+        Assert.assertTrue(duration <= MAX_TIME);
     }
 
     @Test
     public void testScrabble_StartOnPerformance() {
 
-        String message = "words that start with joy yes margaret, i will bring out the trash";
+        String message = "words that start with a yes margaret, i will bring out the trash";
 
-        long startTime = System.currentTimeMillis();
+        double startTime = System.currentTimeMillis();
 
         mm.decodeMsg(message, settings, databaseCom, context, state);
 
-        long endTime = System.currentTimeMillis();
-        long duration = (endTime - startTime) / 1000;      // Transform to seconds
-
-        Assert.assertTrue(duration < MAX_TIME);
+        double endTime = System.currentTimeMillis();
+        double duration = (endTime - startTime) / 1000;      // Convert from miliseconds to seconds
+        
+        System.out.println("Scrabble functions take "+duration+" seconds.");
+        Assert.assertTrue(duration <= MAX_TIME);
     }
 
     @Test
@@ -146,14 +150,15 @@ public class PerformanceTest {
 
         String message = "What can you do";
 
-        long startTime = System.currentTimeMillis();
+        double startTime = System.currentTimeMillis();
 
         mm.decodeMsg(message, settings, databaseCom, context, state);
 
-        long endTime = System.currentTimeMillis();
-        long duration = (endTime - startTime) / 1000;      // Transform to seconds
+        double endTime = System.currentTimeMillis();
+        double duration = (endTime - startTime) / 1000;      // Convert from miliseconds to seconds
 
-        Assert.assertTrue(duration < MAX_TIME);
+        System.out.println("Helper function takes "+duration+" seconds.");
+        Assert.assertTrue(duration <= MAX_TIME);
     }
 
     /**
@@ -165,14 +170,15 @@ public class PerformanceTest {
         String message = "examples of happy";
         mm.decodeMsg(message, settings, databaseCom, context, state);
 
-        long startTime = System.currentTimeMillis();
+        double startTime = System.currentTimeMillis();
 
         message = "more results";
         mm.decodeMsg(message, settings, databaseCom, context, state);
 
-        long endTime = System.currentTimeMillis();
-        long duration = (endTime - startTime) / 1000;      // Transform to seconds
+        double endTime = System.currentTimeMillis();
+        double duration = (endTime - startTime) / 1000;      // Convert from miliseconds to seconds
 
-        Assert.assertTrue(duration < MAX_TIME);
+        System.out.println("Asking for more results takes "+duration+" seconds.");
+        Assert.assertTrue(duration <= MAX_TIME);
     }
 }


### PR DESCRIPTION
Requests made by Prof. Dr. Peinl considered:
- performance tests bis auf erste stelle nach dem komma angeben
- "Sorry, you need to be more precise" nicht mit ausgeben.
- es gibt nicht MEHR resultate für ww statt aktueller msg für result ==
null bei more